### PR TITLE
AE Ticker #1 Basic Authentication

### DIFF
--- a/Tabloid/Models/Category.cs
+++ b/Tabloid/Models/Category.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Tabloid.Models
+{
+    public class Category
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+    }
+}

--- a/Tabloid/appsettings.json
+++ b/Tabloid/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "server=localhost\\SQLExpress;database=Tabloid;integrated security=true"
+    "DefaultConnection": "server=localhost\\SQLExpress;database=Tabloid;integrated security=true;Trusted_Connection=True;TrustServerCertificate=True;"
   }
 }

--- a/Tabloid/client/src/providers/UserProfileProvider.js
+++ b/Tabloid/client/src/providers/UserProfileProvider.js
@@ -6,7 +6,7 @@ export const UserProfileContext = createContext();
 
 export function UserProfileProvider(props) {
 
-  const apiUrl = "https://localhost:44360";
+  const apiUrl = "https://localhost:5001";
 
   const userProfile = sessionStorage.getItem("userProfile");
   const [isLoggedIn, setIsLoggedIn] = useState(userProfile != null);


### PR DESCRIPTION
# Description

This is for Ticket#1(https://trello.com/c/54f5QUs9/1-1-basic-authentication), which checks to see if an unauthenticated user has the user’s e-mail address in the local User Profile database.  And if the email is in the database, the user can log in and will be directed to the homepage.  If the email has not been added to the database and the user attempts to log in, the error message should be displayed. 

# Type of change
No change 

# Testing Instructions
**Testing objectives**

1. To check whether the app will direct to the login page when an unauthenticated user is in the Tabloid application and clicks any link
2. To see whether the app will display the login form for the unauthenticated user
3. To see whether  the app direct the user to the home page after the user enter an email address in the form and the email address matches an existing User Profile
4. To see whether the app display an error message after the user enter an email address in the form and the email address does not match an existing User Profile
5. To see weather the unauthenticated user can enter a valid email address after a failed login attempt 

**Testing instructions**

1. In Terminal, cloning down this repository to your local repository.
2. If you currently do not have access to this branch, run a <git fetch --all>, then to navigate to this branch ae-BasicAuthentification by typing git checkout ae-BasicAuthentification in Terminal. And type Start Tabloid.sln in Terminal to run this program through Visual Studio 2022.
3. If you have not created or seeded the basic database, you will need to do so. First, open a new query by right clicking on Tabloid under the database file in the SQL Server Object Explorer on the left.
4. You will need to create the table first and then add the seed data. Choose files in the following order:
5. [01_Tabloid_Create_DB.sql](https://github.com/NewForce-Cohort-5/tabloidfullstack-the-pollening/blob/main/SQL/01_Tabloid_Create_DB.sql)
6. [02_Tabloid_Seed_Data.sql](https://github.com/NewForce-Cohort-5/tabloidfullstack-the-pollening/blob/main/SQL/02_Tabloid_Seed_Data.sql)
7. To run the query, please click the green outlined arrow under the query tab.
8. Please run the following sql commands to check the database tables have been created  and to check the data is in the   the UserProfile table

  ```
SELECT  * FROM 
INFORMATION_SCHEMA.TABLES;
GO
Select * from UserProfile;
```

9. To run the back end server, please change the solid green debugger database from IISExpress to Tabloid and click the solid green debugger play button.
10. The swagger UI should run in a browser. 
11. And then on the client side, please update the value of the variable called apiUrl to "https://localhost:5001/" In the UserProfile.js
12. Execute the npm start command on the terminal at the level where you can see package.json
13. A browser should start to run the program with “localhost” as a part of the URL. The opening page should be the Log-in page (testing objective 2). 
14. Please change a part of the url from login to home or to post in order to test the app will direct you to the login page (testing objective 1)
15. Please use this fake e-mail address (you@not.here) for the first log-in attempt.  This email address should not be in your database.  This is to test the app will display an error message when an unregistered email was used to log in (testing objective 4)
16. After clearing the error message, please test to see whether the app will let you still log in (testing objective 5)
17. Please log in using this email address that should be in your database to log in: [foo@bar.com](mailto:foo@bar.com) and check to see if the app directs you to the homepage (testing objective 3)
18. If there are no issues, please go back to Terminal and run the following command ‘git checkout main’ to get back to the local main branch



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works